### PR TITLE
fix bugs in get_slaves

### DIFF
--- a/lib/resty/redis/sentinel.lua
+++ b/lib/resty/redis/sentinel.lua
@@ -39,7 +39,7 @@ function _M.get_slaves(sentinel, master_name)
                 host[slave[i]] = slave[i + 1]
             end
 
-            if host["master-link-status"] == "ok" then
+            if host["flags"] and not string.find(host["flags"],"s_down") then
                 host.host = host.ip -- for parity with other functions
                 tbl_insert(hosts, host)
             end


### PR DESCRIPTION
"flags" should be used to check whether the slave can be visited instead of master-link-status.
Whe the master is down, master-link-status of all slaves is "down".