### PR TITLE
Add Sentinel password support

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ When connecting via Redis Sentinel, the format is as follows:
 
 Again, `PASSWORD` and `DB` are optional. `ROLE` must be either `m` or `s` for master / slave respectively.
 
+On versions of Redis newer than 5.0.1, Sentinels can optionally require their own password. If enabled, provide this password in the `sentinel_password` parameter.
+
 A table of `sentinels` must also be supplied. e.g.
 
 ```lua
@@ -98,7 +100,8 @@ local redis, err = rc:connect{
     url = "sentinel://mymaster:a/2",
     sentinels = {
         { host = "127.0.0.1", port = 26379 },
-    }
+    },
+    sentinel_password = "password"
 }
 ```
 
@@ -133,6 +136,7 @@ If configured as a table of commands, the command methods will be replaced by a 
     port = "6379",
     path = "",  -- unix socket path, e.g. /tmp/redis.sock
     password = "",
+    sentinel_password = "",
     db = 0,
 
     master_name = "mymaster",

--- a/lib/resty/redis/connector.lua
+++ b/lib/resty/redis/connector.lua
@@ -95,6 +95,7 @@ local DEFAULTS = setmetatable({
     port = 6379,
     path = "", -- /tmp/redis.sock
     password = "",
+    sentinel_password = "",
     db = 0,
     url = "", -- DSN url
 
@@ -227,6 +228,12 @@ function _M.connect_via_sentinel(self, params)
     local role = params.role
     local db = params.db
     local password = params.password
+    local sentinel_password = params.sentinel_password
+    if sentinel_password then
+      for i,host in ipairs(sentinels) do
+        host.password = sentinel_password
+      end
+    end
 
     local sentnl, err, previous_errors = self:try_hosts(sentinels)
     if not sentnl then

--- a/lua-resty-redis-connector-0.08.rockspec
+++ b/lua-resty-redis-connector-0.08.rockspec
@@ -1,8 +1,8 @@
 package = "lua-resty-redis-connector"
-version = "0.07-1"
+version = "0.08"
 source = {
   url = "git://github.com/ledgetech/lua-resty-redis-connector",
-  tag = "v0.07"
+  tag = "v0.08"
 }
 description = {
   summary = "Connection utilities for lua-resty-redis.",


### PR DESCRIPTION
Add a new sentinel_password parameter, and send AUTH commands to Sentinels if it is present.

https://github.com/antirez/redis/commit/fa675256c127963c74ea68f8bab22ef105bada02 added authentication support to Sentinel, and this was released to stable in 5.0.1: https://raw.githubusercontent.com/antirez/redis/5.0/00-RELEASENOTES