### PR TITLE
Fixes around creating new connections

### DIFF
--- a/lib/resty/redis/connector.lua
+++ b/lib/resty/redis/connector.lua
@@ -381,7 +381,7 @@ function _M.connect_to_host(self, host)
 end
 
 
-local function set_keepalive(self, redis)
+function _M.set_keepalive(self, redis)
     -- Restore connection to "NORMAL" before putting into keepalive pool,
     -- ignoring any errors.
     -- Proxied Redis does not support transactions.
@@ -394,8 +394,6 @@ local function set_keepalive(self, redis)
         config.keepalive_timeout, config.keepalive_poolsize
     )
 end
-_M.set_keepalive = set_keepalive
-
 
 
 -- Deprecated: use config table in new() or connect() instead.

--- a/lib/resty/redis/connector.lua
+++ b/lib/resty/redis/connector.lua
@@ -263,11 +263,11 @@ function _M.connect_via_sentinel(self, params)
     else
         -- We want a slave
         local slaves, err = get_slaves(sentnl, master_name)
-        sentnl:set_keepalive()
-
         if not slaves then
             return nil, err
         end
+
+        sentnl:set_keepalive()
 
         -- Put any slaves on 127.0.0.1 at the front
         tbl_sort(slaves, sort_by_localhost)
@@ -282,9 +282,9 @@ function _M.connect_via_sentinel(self, params)
         local slave, err, previous_errors = self:try_hosts(slaves)
         if not slave then
             return nil, err, previous_errors
-        else
-            return slave
         end
+
+        return slave
     end
 end
 

--- a/lib/resty/redis/connector.lua
+++ b/lib/resty/redis/connector.lua
@@ -247,19 +247,17 @@ function _M.connect_via_sentinel(self, params)
             return nil, err
         end
 
+        sentnl:set_keepalive()
+
         master.db = db
         master.password = password
 
         local redis, err = self:connect_to_host(master)
-        if redis then
-            sentnl:set_keepalive()
-            return redis, err
-        else
-            if role == "master" then
-                return nil, err
-            end
+        if not redis then
+            return nil, err
         end
 
+        return redis
     else
         -- We want a slave
         local slaves, err = get_slaves(sentnl, master_name)

--- a/t/connector.t
+++ b/t/connector.t
@@ -210,8 +210,8 @@ location /t {
 }
 --- request
 GET /t
---- error_log
-ERR Client sent AUTH, but no password is set
+--- no_error_log
+[error]
 
 
 === TEST 7: Bad unix domain socket path should fail

--- a/t/sentinel.t
+++ b/t/sentinel.t
@@ -32,7 +32,7 @@ location /t {
 		local rc = require("resty.redis.connector").new()
 
 		local sentinel, err = rc:connect{ url = "redis://127.0.0.1:$TEST_NGINX_SENTINEL_PORT1" }
-		assert(sentinel and not err, "sentinel should connect without errors")
+		assert(sentinel and not err, "sentinel should connect without errors but got " .. tostring(err))
 
 		local master, err = require("resty.redis.sentinel").get_master(
 			sentinel,


### PR DESCRIPTION
A few fixes separated into a few commits:
* pass error from socket when connector fails to select a database, so that "timeout" error isn't hidden away from the user (without this we can get a connection with closed socket and not know about that until we try to use it, it may happen when connection gets broken outside of nginx)
* slave connection: use `set_keepalive` only when we are sure that Sentinel responded correctly - it may have timed out, and we don't want to put such connection in pool
* master connection: use `set_keepalive` always when Sentinel responded correctly, regardless of result of connecting to indicated Redis instance