### PR TITLE
Fix issue retrieving available slaves via Sentinel

### DIFF
--- a/lib/resty/redis/sentinel.lua
+++ b/lib/resty/redis/sentinel.lua
@@ -39,7 +39,11 @@ function _M.get_slaves(sentinel, master_name)
                 host[slave[i]] = slave[i + 1]
             end
 
-            if host["master-link-status"] == "ok" then
+            local master_link_status_ok = host["master-link-status"] == "ok"
+            local is_down = host["flags"] and (string.find(host["flags"],"s_down")
+                or string.find(host["flags"],"o_down")
+                or string.find(host["flags"],"disconnected"))
+            if master_link_status_ok and not is_down then
                 host.host = host.ip -- for parity with other functions
                 tbl_insert(hosts, host)
             end

--- a/lib/resty/redis/sentinel.lua
+++ b/lib/resty/redis/sentinel.lua
@@ -41,7 +41,6 @@ function _M.get_slaves(sentinel, master_name)
 
             local master_link_status_ok = host["master-link-status"] == "ok"
             local is_down = host["flags"] and (string.find(host["flags"],"s_down")
-                or string.find(host["flags"],"o_down")
                 or string.find(host["flags"],"disconnected"))
             if master_link_status_ok and not is_down then
                 host.host = host.ip -- for parity with other functions


### PR DESCRIPTION
A [previous PR](https://github.com/ledgetech/lua-resty-redis-connector/pull/32) was submitted to fix this issue but it broke the tests and it was not clear whether the situation of a slave having a flag of `s_down` could occur when its `master-link-status` was `ok`. I have found that this is a situation that is very possible to get into as described in [this comment](https://github.com/ledgetech/lua-resty-redis-connector/pull/32#issuecomment-681960766).

This change updates the client to be on par with other languages' sentinel clients in terms of how slaves are determined to be healthy/available. See [here](https://github.com/redis/redis-rb/pull/829) and [here](https://github.com/lettuce-io/lettuce-core/blob/main/src/main/java/io/lettuce/core/masterreplica/SentinelTopologyProvider.java#L121) as examples.