### PR TITLE
Add support for usernames (Redis ACL)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: trusty
+dist: focal
 
 os: linux
 
@@ -9,9 +9,10 @@ compiler: gcc
 
 addons:
   apt:
+    sources:
+      - sourceline: 'ppa:redislabs/redis'
     packages:
       - luarocks
-      - redis
       - lsof
 
 cache:
@@ -37,6 +38,10 @@ env:
     - NGINX_VERSION=1.17.8
 
 before_install:
+  # we can't update redis in addons.apt.packages as updated package automatically tries to start and immediately fails
+  - echo exit 101 | sudo tee /usr/sbin/policy-rc.d
+  - sudo chmod +x /usr/sbin/policy-rc.d
+  - sudo apt-get install -y redis-server
   - sudo luarocks install luacov
   - sudo luarocks install lua-resty-redis
   - sudo luarocks install luacheck $LUACHECK_VER

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ OPENRESTY_PREFIX    = /usr/local/openresty
 
 TEST_FILE          ?= t
 TMP_DIR			   ?= /tmp
-SENTINEL_TEST_FILE ?= $(TEST_FILE)/sentinel
 
 REDIS_CMD           = redis-server
 SENTINEL_CMD        = $(REDIS_CMD) --sentinel

--- a/README.md
+++ b/README.md
@@ -81,19 +81,22 @@ If the `params.url` field is present then it will be parsed to set the other par
 
 The format for connecting directly to Redis is:
 
-`redis://PASSWORD@HOST:PORT/DB`
+`redis://USERNAME:PASSWORD@HOST:PORT/DB`
 
-The `PASSWORD` and `DB` fields are optional, all other components are required.
+The `USERNAME`, `PASSWORD` and `DB` fields are optional, all other components are required.
+
+Use of username requires Redis 6.0.0 or newer.
 
 ### Connections via Redis Sentinel
 
 When connecting via Redis Sentinel, the format is as follows:
 
-`sentinel://PASSWORD@MASTER_NAME:ROLE/DB`
+`sentinel://USERNAME:PASSWORD@MASTER_NAME:ROLE/DB`
 
-Again, `PASSWORD` and `DB` are optional. `ROLE` must be either `m` or `s` for master / slave respectively.
+Again, `USERNAME`, `PASSWORD` and `DB` are optional. `ROLE` must be either `m` or `s` for master / slave respectively.
 
 On versions of Redis newer than 5.0.1, Sentinels can optionally require their own password. If enabled, provide this password in the `sentinel_password` parameter.
+On Redis 6.2.0 and newer you can pass username using `sentinel_username` parameter.
 
 A table of `sentinels` must also be supplied. e.g.
 
@@ -103,6 +106,7 @@ local redis, err = rc:connect{
     sentinels = {
         { host = "127.0.0.1", port = 26379 },
     },
+    sentinel_username = "default",
     sentinel_password = "password"
 }
 ```
@@ -137,7 +141,9 @@ If configured as a table of commands, the command methods will be replaced by a 
     host = "127.0.0.1",
     port = "6379",
     path = "",  -- unix socket path, e.g. /tmp/redis.sock
+    username = "",
     password = "",
+    sentinel_username = "",
     sentinel_password = "",
     db = 0,
 

--- a/lib/resty/redis/sentinel.lua
+++ b/lib/resty/redis/sentinel.lua
@@ -21,6 +21,8 @@ function _M.get_master(sentinel, master_name)
     )
     if res and res ~= ngx_null and res[1] and res[2] then
         return { host = res[1], port = res[2] }
+    elseif res == ngx_null then
+        return nil, "invalid master name"
     else
         return nil, err
     end

--- a/t/config.t
+++ b/t/config.t
@@ -120,6 +120,7 @@ location /t {
             host = "127.0.0.1",
             port = $TEST_NGINX_REDIS_PORT,
             path = "",
+            username = "",
             password = "",
             db = 0,
 
@@ -144,6 +145,7 @@ location /t {
             host = "127.0.0.1",
             port = $TEST_NGINX_REDIS_PORT,
             path = "",
+            username = "",
             password = "",
             db = 0,
 

--- a/t/config.t
+++ b/t/config.t
@@ -15,7 +15,7 @@ init_by_lua_block {
 }
 };
 
-$ENV{TEST_NGINX_REDIS_PORT} ||= 6379;
+$ENV{TEST_NGINX_REDIS_PORT} ||= 6380;
 
 no_long_string();
 run_tests();

--- a/t/connector.t
+++ b/t/connector.t
@@ -12,7 +12,8 @@ init_by_lua_block {
 };
 
 $ENV{TEST_NGINX_RESOLVER} = '8.8.8.8';
-$ENV{TEST_NGINX_REDIS_PORT} ||= 6379;
+$ENV{TEST_NGINX_REDIS_PORT} ||= 6380;
+$ENV{TEST_NGINX_REDIS_PORT_AUTH} ||= 6393;
 $ENV{TEST_NGINX_REDIS_SOCKET} ||= 'unix://tmp/redis/redis.sock';
 
 no_long_string();
@@ -401,6 +402,12 @@ location /t {
         assert(redis and not err, "connect should return positively")
         assert(redis:set("cat", "dog") and redis:get("cat") == "dog")
 
+        local redis, err = rc2:connect({
+            url = "redis://redisuser:redisuserpass@127.0.0.1:$TEST_NGINX_REDIS_PORT_AUTH/"
+        })
+        assert(redis and not err, "connect should return positively")
+        local username = assert(redis:acl("whoami"))
+        assert(username == "redisuser", "should connect as 'redisuser' but got " .. tostring(username))
     }
 }
 --- request

--- a/t/proxy.t
+++ b/t/proxy.t
@@ -12,7 +12,7 @@ init_by_lua_block {
 };
 
 $ENV{TEST_NGINX_RESOLVER} = '8.8.8.8';
-$ENV{TEST_NGINX_REDIS_PORT} ||= 6379;
+$ENV{TEST_NGINX_REDIS_PORT} ||= 6380;
 
 no_long_string();
 run_tests();


### PR DESCRIPTION
This adds support for `username` / `sentinel_username` parameters which are used to authenticate using new form of [AUTH](https://redis.io/commands/auth) command from Redis 6.0.

From what I see travis.yml uses Trusty (i.e. Redis 2.8), so I didn't add tests covering this. I can include tests that assume Redis 6+ is installed, but I never used Travis so I'm not sure i can easily upgrade it.

If you need, I tested in Docker environemnt and installed newest Redis using:
```sh
RUN echo "deb http://ppa.launchpad.net/redislabs/redis/ubuntu focal main" > /etc/apt/sources.list.d/redis.list && \
    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 60A0586666DE0BA4B481628ACC59E6B43FA6E3CA && \
    apt-get update -oDir::Etc::sourcelist=sources.list.d/redis.list -o Dir::Etc::sourceparts=- --no-list-cleanup && \
    apt-get install -y redis redis-sentinel
```