### PR TITLE
feat/send timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ env:
     - TEST_NGINX_SLEEP=0.006
     - LUACHECK_VER=0.21.1
   jobs:
-    - NGINX_VERSION=1.19.3
+    - NGINX_VERSION=1.19.9
 
 before_install:
   # we can't update redis in addons.apt.packages as updated package automatically tries to start and immediately fails

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ env:
     - TEST_NGINX_SLEEP=0.006
     - LUACHECK_VER=0.21.1
   jobs:
-    - NGINX_VERSION=1.17.8
+    - NGINX_VERSION=1.19.3
 
 before_install:
   # we can't update redis in addons.apt.packages as updated package automatically tries to start and immediately fails

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ More verbose configuration, with timeouts and a default password:
 ```lua
 local rc = require("resty.redis.connector").new({
     connect_timeout = 50,
+    send_timeout = 5000,
     read_timeout = 5000,
     keepalive_timeout = 30000,
     password = "mypass",
@@ -43,6 +44,7 @@ Keep all config in a table, to easily create / close connections as needed:
 ```lua
 local rc = require("resty.redis.connector").new({
     connect_timeout = 50,
+    send_timeout = 5000,
     read_timeout = 5000,
     keepalive_timeout = 30000,
 
@@ -149,10 +151,14 @@ the server
 ```lua
 {
     connect_timeout = 100,
+    send_timeout = 1000,
     read_timeout = 1000,
-    connection_options = {}, -- pool, etc
     keepalive_timeout = 60000,
     keepalive_poolsize = 30,
+
+    -- ssl, ssl_verify, server_name, pool, pool_size, backlog
+    -- see: https://github.com/openresty/lua-resty-redis#connect
+    connection_options = {},
 
     host = "127.0.0.1",
     port = "6379",

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # lua-resty-redis-connector
 
-[![Build Status](https://travis-ci.org/ledgetech/lua-resty-redis-connector.svg?branch=master)](https://travis-ci.org/ledgetech/lua-resty-redis-connector)
+[![Build
+Status](https://travis-ci.org/ledgetech/lua-resty-redis-connector.svg?branch=master)](https://travis-ci.org/ledgetech/lua-resty-redis-connector)
 
-Connection utilities for [lua-resty-redis](https://github.com/openresty/lua-resty-redis), making it easy and reliable to connect to Redis hosts, either directly or via [Redis Sentinel](http://redis.io/topics/sentinel).
+Connection utilities for
+[lua-resty-redis](https://github.com/openresty/lua-resty-redis), making it easy
+and reliable to connect to Redis hosts, either directly or via [Redis
+Sentinel](http://redis.io/topics/sentinel).
 
 
 ## Synopsis
@@ -55,7 +59,8 @@ local redis, err = rc:connect()
 local ok, err = rc:set_keepalive(redis)
 ```
 
-[connect](#connect) can be used to override some defaults given in [new](#new), which are pertinent to this connection only.
+[connect](#connect) can be used to override some defaults given in [new](#new),
+which are pertinent to this connection only.
 
 
 ```lua
@@ -73,9 +78,11 @@ local redis, err = rc:connect({
 
 ## DSN format
 
-If the `params.url` field is present then it will be parsed to set the other params. Any manually specified params will override values given in the DSN.
+If the `params.url` field is present then it will be parsed to set the other
+params. Any manually specified params will override values given in the DSN.
 
-*Note: this is a behaviour change as of v0.06. Previously, the DSN values would take precedence.*
+*Note: this is a behaviour change as of v0.06. Previously, the DSN values would
+take precedence.*
 
 ### Direct Redis connections
 
@@ -83,7 +90,8 @@ The format for connecting directly to Redis is:
 
 `redis://USERNAME:PASSWORD@HOST:PORT/DB`
 
-The `USERNAME`, `PASSWORD` and `DB` fields are optional, all other components are required.
+The `USERNAME`, `PASSWORD` and `DB` fields are optional, all other components
+are required.
 
 Use of username requires Redis 6.0.0 or newer.
 
@@ -93,10 +101,13 @@ When connecting via Redis Sentinel, the format is as follows:
 
 `sentinel://USERNAME:PASSWORD@MASTER_NAME:ROLE/DB`
 
-Again, `USERNAME`, `PASSWORD` and `DB` are optional. `ROLE` must be either `m` or `s` for master / slave respectively.
+Again, `USERNAME`, `PASSWORD` and `DB` are optional. `ROLE` must be either `m`
+or `s` for master / slave respectively.
 
-On versions of Redis newer than 5.0.1, Sentinels can optionally require their own password. If enabled, provide this password in the `sentinel_password` parameter.
-On Redis 6.2.0 and newer you can pass username using `sentinel_username` parameter.
+On versions of Redis newer than 5.0.1, Sentinels can optionally require their
+own password. If enabled, provide this password in the `sentinel_password`
+parameter. On Redis 6.2.0 and newer you can pass username using
+`sentinel_username` parameter.
 
 A table of `sentinels` must also be supplied. e.g.
 
@@ -113,19 +124,24 @@ local redis, err = rc:connect{
 
 ## Proxy Mode
 
-Enable the `connection_is_proxied` parameter if connecting to Redis through a proxy service (e.g. Twemproxy).
-These proxies generally only support a limited sub-set of Redis commands, those which do not require state and do not affect multiple keys.
-Databases and transactions are also not supported.
+Enable the `connection_is_proxied` parameter if connecting to Redis through a
+proxy service (e.g. Twemproxy). These proxies generally only support a limited
+sub-set of Redis commands, those which do not require state and do not affect
+multiple keys. Databases and transactions are also not supported.
 
-Proxy mode will disable switching to a DB on connect.
-Unsupported commands (defaults to those not supported by Twemproxy) will return `nil, err` immediately rather than being sent to the proxy, which can result in dropped connections.
+Proxy mode will disable switching to a DB on connect. Unsupported commands
+(defaults to those not supported by Twemproxy) will return `nil, err`
+immediately rather than being sent to the proxy, which can result in dropped
+connections.
 
 `discard` will not be sent when adding connections to the keepalive pool
 
 
 ## Disabled commands
 
-If configured as a table of commands, the command methods will be replaced by a function which immediately returns `nil, err` without forwarding the command to the server
+If configured as a table of commands, the command methods will be replaced by a
+function which immediately returns `nil, err` without forwarding the command to
+the server
 
 ## Default Parameters
 
@@ -175,16 +191,21 @@ If configured as a table of commands, the command methods will be replaced by a 
 
 `syntax: rc = redis_connector.new(params)`
 
-Creates the Redis Connector object, overring default params with the ones given. In case of failures, returns `nil` and a string describing the error.
+Creates the Redis Connector object, overring default params with the ones given.
+In case of failures, returns `nil` and a string describing the error.
 
 
 ### connect
 
 `syntax: redis, err = rc:connect(params)`
 
-Attempts to create a connection, according to the [params](#parameters) supplied, falling back to defaults given in `new` or the predefined defaults. If a connection cannot be made, returns `nil` and a string describing the reason.
+Attempts to create a connection, according to the [params](#parameters)
+supplied, falling back to defaults given in `new` or the predefined defaults. If
+a connection cannot be made, returns `nil` and a string describing the reason.
 
-Note that `params` given here do not change the connector's own configuration, and are only used to alter this particular connection operation. As such, the following parameters have no meaning when given in `connect`.
+Note that `params` given here do not change the connector's own configuration,
+and are only used to alter this particular connection operation. As such, the
+following parameters have no meaning when given in `connect`.
 
 * `keepalive_poolsize`
 * `keepalive_timeout`
@@ -196,24 +217,28 @@ Note that `params` given here do not change the connector's own configuration, a
 
 `syntax: ok, err = rc:set_keepalive(redis)`
 
-Attempts to place the given Redis connection on the keepalive pool, according to timeout and poolsize params given in `new` or the predefined defaults.
+Attempts to place the given Redis connection on the keepalive pool, according to
+timeout and poolsize params given in `new` or the predefined defaults.
 
-This allows an application to release resources without having to keep track of application wide keepalive settings.
+This allows an application to release resources without having to keep track of
+application wide keepalive settings.
 
 Returns `1` or in the case of error, `nil` and a string describing the error.
 
 
 ## Utilities
 
-The following methods are not typically needed, but may be useful if a custom interface is required.
+The following methods are not typically needed, but may be useful if a custom
+interface is required.
 
 
 ### connect_via_sentinel
 
 `syntax: redis, err = rc:connect_via_sentinel(params)`
 
-Returns a Redis connection by first accessing a sentinel as supplied by the `params.sentinels` table,
-and querying this with the `params.master_name` and `params.role`.
+Returns a Redis connection by first accessing a sentinel as supplied by the
+`params.sentinels` table, and querying this with the `params.master_name` and
+`params.role`.
 
 
 ### try_hosts
@@ -234,14 +259,16 @@ Attempts to connect to the supplied `host`.
 
 `syntax: master, err = sentinel.get_master(sentinel, master_name)`
 
-Given a connected Sentinel instance and a master name, will return the current master Redis instance.
+Given a connected Sentinel instance and a master name, will return the current
+master Redis instance.
 
 
 ### sentinel.get_slaves
 
 `syntax: slaves, err = sentinel.get_slaves(sentinel, master_name)`
 
-Given a connected Sentinel instance and a master name, will return a list of registered slave Redis instances.
+Given a connected Sentinel instance and a master name, will return a list of
+registered slave Redis instances.
 
 
 # Author
@@ -257,10 +284,23 @@ Copyright (c) James Hurst <james@pintsized.co.uk>
 
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
 
-* Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
 
-* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+* Redistributions in binary form must reproduce the above copyright notice, this
+  list of conditions and the following disclaimer in the documentation and/or
+  other materials provided with the distribution.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/lib/resty/redis/connector.lua
+++ b/lib/resty/redis/connector.lua
@@ -201,7 +201,7 @@ end
 -- same as read_timeout. So if only the latter is given, ensure the former
 -- matches.
 local function apply_fallback_send_timeout(config)
-    if not config.send_timeout and config.read_timeout then
+    if config and not config.send_timeout and config.read_timeout then
         config.send_timeout = config.read_timeout
     end
 end

--- a/lib/resty/redis/connector.lua
+++ b/lib/resty/redis/connector.lua
@@ -193,6 +193,7 @@ local function apply_dsn(config)
         config, err = parse_dsn(config)
         if err then ngx_log(ngx_ERR, err) end
     end
+    return config
 end
 
 
@@ -207,7 +208,7 @@ end
 
 
 function _M.new(config)
-    apply_dsn(config)
+    config = apply_dsn(config)
     apply_fallback_send_timeout(config)
 
     local ok, config = pcall(tbl_copy_merge_defaults, config, DEFAULTS)
@@ -229,7 +230,7 @@ end
 
 
 function _M.connect(self, params)
-    apply_dsn(params)
+    params = apply_dsn(params)
     apply_fallback_send_timeout(params)
 
     params = tbl_copy_merge_defaults(params, self.config)

--- a/lib/resty/redis/connector.lua
+++ b/lib/resty/redis/connector.lua
@@ -186,13 +186,29 @@ end
 _M.parse_dsn = parse_dsn
 
 
-function _M.new(config)
-    -- Fill out gaps in config with any dsn params
+-- Fill out gaps in config with any dsn params
+local function apply_dsn(config)
     if config and config.url then
         local err
         config, err = parse_dsn(config)
         if err then ngx_log(ngx_ERR, err) end
     end
+end
+
+
+-- For backwards compatability; previously send_timeout was implicitly the
+-- same as read_timeout. So if only the latter is given, ensure the former
+-- matches.
+local function apply_fallback_send_timeout(config)
+    if not config.send_timeout and config.read_timeout then
+        config.send_timeout = config.read_timeout
+    end
+end
+
+
+function _M.new(config)
+    apply_dsn(config)
+    apply_fallback_send_timeout(config)
 
     local ok, config = pcall(tbl_copy_merge_defaults, config, DEFAULTS)
     if not ok then
@@ -213,20 +229,10 @@ end
 
 
 function _M.connect(self, params)
-    if params and params.url then
-        local err
-        params, err = parse_dsn(params)
-        if err then ngx_log(ngx_ERR, err) end
-    end
+    apply_dsn(params)
+    apply_fallback_send_timeout(params)
 
     params = tbl_copy_merge_defaults(params, self.config)
-
-    -- For backwards compatability; previously send_timeout was implicitly the
-    -- same as read_timeout. So if only the latter is given, ensure the former
-    -- matches.
-    if not params.send_timeout and params.read_timeout then
-        params.send_timeout = params.read_timeout
-    end
 
     if #params.sentinels > 0 then
         return self:connect_via_sentinel(params)

--- a/t/config.t
+++ b/t/config.t
@@ -79,8 +79,15 @@ location /t {
         assert(rc.config.keepalive_poolsize == 10,
             "keepalive_poolsize should be 10")
 
-        local redis = assert(rc:connect({ port = $TEST_NGINX_REDIS_PORT, disabled_commands = {"set"} }),
-            "rc:connect should return positively")
+        local redis, err = rc:connect({
+            port = $TEST_NGINX_REDIS_PORT,
+            disabled_commands = { "set" }
+        })
+
+        if not redis then
+            ngx.log(ngx.ERR, "connect failed: ", err)
+            return
+        end
 
         local ok, err = redis:set("foo", "bar")
             assert( ok == nil and (string.find(err, "disabled") ~= nil) , "Disabled commands not passed through" )

--- a/t/config.t
+++ b/t/config.t
@@ -10,6 +10,8 @@ my $pwd = cwd();
 our $HttpConfig = qq{
 lua_package_path "$pwd/lib/?.lua;;";
 
+lua_socket_log_errors On;
+
 init_by_lua_block {
     require("luacov.runner").init()
 }
@@ -84,7 +86,7 @@ location /t {
             disabled_commands = { "set" }
         })
 
-        if not redis then
+        if not redis or err then
             ngx.log(ngx.ERR, "connect failed: ", err)
             return
         end

--- a/t/config.t
+++ b/t/config.t
@@ -9,8 +9,7 @@ my $pwd = cwd();
 
 our $HttpConfig = qq{
 lua_package_path "$pwd/lib/?.lua;;";
-
-lua_socket_log_errors On;
+lua_socket_log_errors Off;
 
 init_by_lua_block {
     require("luacov.runner").init()

--- a/t/connector.t
+++ b/t/connector.t
@@ -5,6 +5,7 @@ my $pwd = cwd();
 
 our $HttpConfig = qq{
 lua_package_path "$pwd/lib/?.lua;;";
+lua_socket_log_errors Off;
 
 init_by_lua_block {
     require("luacov.runner").init()

--- a/t/connector.t
+++ b/t/connector.t
@@ -295,35 +295,35 @@ location /t {
         assert(params and not err,
             "url should parse without error: " .. tostring(err))
 
-		assert(params.host == "127.0.0.1", "host should be localhost")
-		assert(tonumber(params.port) == $TEST_NGINX_REDIS_PORT,
-			"port should be $TEST_NGINX_REDIS_PORT")
-		assert(tonumber(params.db) == 4, "db should be 4")
-		assert(params.password == "foo", "password should be foo")
+        assert(params.host == "127.0.0.1", "host should be localhost")
+        assert(tonumber(params.port) == $TEST_NGINX_REDIS_PORT,
+            "port should be $TEST_NGINX_REDIS_PORT")
+        assert(tonumber(params.db) == 4, "db should be 4")
+        assert(params.password == "foo", "password should be foo")
 
 
-		local user_params = {
-			url = "sentinel://foo:bar@foomaster:s/2"
-		}
+        local user_params = {
+            url = "sentinel://foo:bar@foomaster:s/2"
+        }
 
-		local params, err = rc.parse_dsn(user_params)
-		assert(params and not err,
-			"url should parse without error: " .. tostring(err))
+        local params, err = rc.parse_dsn(user_params)
+        assert(params and not err,
+            "url should parse without error: " .. tostring(err))
 
-		assert(params.master_name == "foomaster", "master_name should be foomaster")
-		assert(params.role == "slave", "role should be slave")
-		assert(tonumber(params.db) == 2, "db should be 2")
-		assert(params.username == "foo", "username should be foo")
-		assert(params.password == "bar", "password should be bar")
+        assert(params.master_name == "foomaster", "master_name should be foomaster")
+        assert(params.role == "slave", "role should be slave")
+        assert(tonumber(params.db) == 2, "db should be 2")
+        assert(params.username == "foo", "username should be foo")
+        assert(params.password == "bar", "password should be bar")
 
 
-		local params = {
-			url = "sentinels:/wrongformat",
-		}
+        local params = {
+            url = "sentinels:/wrongformat",
+        }
 
-		local ok, err = rc.parse_dsn(params)
-		assert(not ok and err == "could not parse DSN: nil",
-			"url should fail to parse")
+        local ok, err = rc.parse_dsn(params)
+        assert(not ok and err == "could not parse DSN: nil",
+            "url should fail to parse")
     }
 }
 --- request

--- a/t/proxy.t
+++ b/t/proxy.t
@@ -5,6 +5,7 @@ my $pwd = cwd();
 
 our $HttpConfig = qq{
 lua_package_path "$pwd/lib/?.lua;;";
+lua_socket_log_errors Off;
 
 init_by_lua_block {
     require("luacov.runner").init()

--- a/t/sentinel.t
+++ b/t/sentinel.t
@@ -5,6 +5,7 @@ my $pwd = cwd();
 
 our $HttpConfig = qq{
 lua_package_path "$pwd/lib/?.lua;;";
+lua_socket_log_errors Off;
 
 init_by_lua_block {
     require("luacov.runner").init()

--- a/t/sentinel.t
+++ b/t/sentinel.t
@@ -29,26 +29,26 @@ __DATA__
 --- http_config eval: $::HttpConfig
 --- config
 location /t {
-	content_by_lua_block {
-		local rc = require("resty.redis.connector").new()
+    content_by_lua_block {
+        local rc = require("resty.redis.connector").new()
         local rs = require("resty.redis.sentinel")
 
-		local sentinel, err = rc:connect{ url = "redis://127.0.0.1:$TEST_NGINX_SENTINEL_PORT1" }
-		assert(sentinel and not err, "sentinel should connect without errors but got " .. tostring(err))
+        local sentinel, err = rc:connect{ url = "redis://127.0.0.1:$TEST_NGINX_SENTINEL_PORT1" }
+        assert(sentinel and not err, "sentinel should connect without errors but got " .. tostring(err))
 
-		local master, err = rs.get_master(sentinel, "mymaster")
+        local master, err = rs.get_master(sentinel, "mymaster")
 
-		assert(master and not err, "get_master should return the master")
+        assert(master and not err, "get_master should return the master")
 
-		assert(master.host == "127.0.0.1" and tonumber(master.port) == $TEST_NGINX_REDIS_PORT,
-			"host should be 127.0.0.1 and port should be $TEST_NGINX_REDIS_PORT")
+        assert(master.host == "127.0.0.1" and tonumber(master.port) == $TEST_NGINX_REDIS_PORT,
+            "host should be 127.0.0.1 and port should be $TEST_NGINX_REDIS_PORT")
 
         master, err = rs.get_master(sentinel, "invalid-mymaster")
 
         assert(not master and err, "invalid master name should result in error")
 
-		sentinel:close()
-	}
+        sentinel:close()
+    }
 }
 --- request
 GET /t
@@ -60,22 +60,22 @@ GET /t
 --- http_config eval: $::HttpConfig
 --- config
 location /t {
-	content_by_lua_block {
-		local rc = require("resty.redis.connector").new()
+    content_by_lua_block {
+        local rc = require("resty.redis.connector").new()
 
-		local master, err = rc:connect({
+        local master, err = rc:connect({
             url = "sentinel://mymaster:m/3",
             sentinels = {
                 { host = "127.0.0.1", port = $TEST_NGINX_SENTINEL_PORT1 }
             }
         })
 
-		assert(master and not err, "get_master should return the master")
+        assert(master and not err, "get_master should return the master")
         assert(master:set("foo", "bar"), "set should run without error")
         assert(master:get("foo") == "bar", "get(foo) should return bar")
 
-	    master:close()
-	}
+        master:close()
+    }
 }
 --- request
 GET /t
@@ -98,14 +98,14 @@ location /t {
 
         assert(slaves and not err, "slaves should be returned without error")
 
-		local slaveports = { ["$TEST_NGINX_REDIS_PORT_SL1"] = false, ["$TEST_NGINX_REDIS_PORT_SL2"] = false }
+        local slaveports = { ["$TEST_NGINX_REDIS_PORT_SL1"] = false, ["$TEST_NGINX_REDIS_PORT_SL2"] = false }
 
-		for _,slave in ipairs(slaves) do
-			slaveports[tostring(slave.port)] = true
-		end
+        for _,slave in ipairs(slaves) do
+            slaveports[tostring(slave.port)] = true
+        end
 
-		assert(slaveports["$TEST_NGINX_REDIS_PORT_SL1"] == true and slaveports["$TEST_NGINX_REDIS_PORT_SL2"] == true,
-			"slaves should both be found")
+        assert(slaveports["$TEST_NGINX_REDIS_PORT_SL1"] == true and slaveports["$TEST_NGINX_REDIS_PORT_SL2"] == true,
+            "slaves should both be found")
 
         slaves, err = rs.get_slaves(sentinel, "invalid-mymaster")
 
@@ -128,47 +128,47 @@ location /t {
         local rc = require("resty.redis.connector").new()
 
         local sentinel, err = rc:connect({ url = "redis://127.0.0.1:$TEST_NGINX_SENTINEL_PORT1" })
-		assert(sentinel and not err, "sentinel should connect without error")
+        assert(sentinel and not err, "sentinel should connect without error")
 
         local slaves, err = require("resty.redis.sentinel").get_slaves(
-			sentinel,
-			"mymaster"
-		)
+            sentinel,
+            "mymaster"
+        )
 
-		assert(slaves and not err, "slaves should be returned without error")
+        assert(slaves and not err, "slaves should be returned without error")
 
-		local slaveports = { ["$TEST_NGINX_REDIS_PORT_SL1"] = false, ["$TEST_NGINX_REDIS_PORT_SL2"] = false }
+        local slaveports = { ["$TEST_NGINX_REDIS_PORT_SL1"] = false, ["$TEST_NGINX_REDIS_PORT_SL2"] = false }
 
-		for _,slave in ipairs(slaves) do
-			slaveports[tostring(slave.port)] = true
-		end
+        for _,slave in ipairs(slaves) do
+            slaveports[tostring(slave.port)] = true
+        end
 
-		assert(slaveports["$TEST_NGINX_REDIS_PORT_SL1"] == true and slaveports["$TEST_NGINX_REDIS_PORT_SL2"] == true,
-			"slaves should both be found")
+        assert(slaveports["$TEST_NGINX_REDIS_PORT_SL1"] == true and slaveports["$TEST_NGINX_REDIS_PORT_SL2"] == true,
+            "slaves should both be found")
 
-		-- connect to one and remove it
-		local r = require("resty.redis.connector").new():connect({
-			port = $TEST_NGINX_REDIS_PORT_SL1,
-		})
+        -- connect to one and remove it
+        local r = require("resty.redis.connector").new():connect({
+            port = $TEST_NGINX_REDIS_PORT_SL1,
+        })
         r:slaveof("127.0.0.1", 7000)
 
         ngx.sleep(9)
 
         local slaves, err = require("resty.redis.sentinel").get_slaves(
-			sentinel,
-			"mymaster"
-		)
+            sentinel,
+            "mymaster"
+        )
 
-		assert(slaves and not err, "slaves should be returned without error")
+        assert(slaves and not err, "slaves should be returned without error")
 
-		local slaveports = { ["$TEST_NGINX_REDIS_PORT_SL1"] = false, ["$TEST_NGINX_REDIS_PORT_SL2"] = false }
+        local slaveports = { ["$TEST_NGINX_REDIS_PORT_SL1"] = false, ["$TEST_NGINX_REDIS_PORT_SL2"] = false }
 
-		for _,slave in ipairs(slaves) do
-			slaveports[tostring(slave.port)] = true
-		end
+        for _,slave in ipairs(slaves) do
+            slaveports[tostring(slave.port)] = true
+        end
 
-		assert(slaveports["$TEST_NGINX_REDIS_PORT_SL1"] == false and slaveports["$TEST_NGINX_REDIS_PORT_SL2"] == true,
-			"only $TEST_NGINX_REDIS_PORT_SL2 should be found")
+        assert(slaveports["$TEST_NGINX_REDIS_PORT_SL1"] == false and slaveports["$TEST_NGINX_REDIS_PORT_SL2"] == true,
+            "only $TEST_NGINX_REDIS_PORT_SL2 should be found")
 
         r:slaveof("127.0.0.1", $TEST_NGINX_REDIS_PORT)
 


### PR DESCRIPTION
* Adds a specific `send_timeout` config option and sets all timeouts together with `set_timeouts`. Backwards compatability is maintained by defaulting `send_timeout` to `read_timeout` if the user supplied one. 

* Tidies up some formatting.
