### PR TITLE
Don't send SELECT + ROLE commands to Sentinels

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ the server
 
 `syntax: rc = redis_connector.new(params)`
 
-Creates the Redis Connector object, overring default params with the ones given.
+Creates the Redis Connector object, overriding default params with the ones given.
 In case of failures, returns `nil` and a string describing the error.
 
 
@@ -205,8 +205,8 @@ In case of failures, returns `nil` and a string describing the error.
 
 `syntax: redis, err = rc:connect(params)`
 
-Attempts to create a connection, according to the [params](#parameters)
-supplied, falling back to defaults given in `new` or the predefined defaults. If
+Attempts to create a connection, according to the `params` supplied, falling back
+to [defaults](#default-parameters) given in `new` or the predefined defaults. If
 a connection cannot be made, returns `nil` and a string describing the reason.
 
 Note that `params` given here do not change the connector's own configuration,


### PR DESCRIPTION
In #34 I added error handling in `connect` to properly handle errors after issuing `SELECT`, with a workaround for Sentinels ([link](https://github.com/ledgetech/lua-resty-redis-connector/pull/34/files#diff-6f03d3e17b7772fdea0f4e763e8a9e3f4669641ec046152cf3b9bac737513764R367)). This PR provides a better solution for Sentinels, so that problematic `SELECT` call and subsequent `ROLE` aren't issued.

I did this in a way that allows API to be fully compatible, i.e. old workaround is still there, but internally we avoid issuing invalid command to Sentinel unless user tries to use `connect("redis://sentinel-address")`. To remove this we would need to alter public APIs in some way:
* default to `db = ngx.null`, and use `SELECT` only when `db` is provided - which would make resetting DB to 0 not happen when TCP connection is reused, unless requested explicitly by user
* add a new parameter to connection methods to handle connection initialization